### PR TITLE
Fix width of magic-digit `2` in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ They require 1.16's multi font support and setting `"font":"space:default"`.
 | `5`  | 55 wide    |
 | `4`  | 144 wide   |
 | `3`  | 377 wide   |
-| `2`  | 987 wide   |
+| `2`  | 988 wide   |
 | `1`  | 2584 wide  |
 | `-`  | -6765 wide |


### PR DESCRIPTION
Hi!

I've been using the magic digits in my project, and it works great, except that magic digit "2" does not seem correct.
I think it's 988 pixels wide instead of 987.